### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol (MCP) that provides tools for fetching and creating Red
 
 > **Note**: This is a fork of the [reddit-mcp-server](https://github.com/alexandros-lekkas/reddit-mcp-server) by Alexandros Lekkas, updated with pnpm, tsup build system, and npx execution support.
 
+<a href="https://glama.ai/mcp/servers/@jordanburke/reddit-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jordanburke/reddit-mcp-server/badge" alt="reddit-mcp-server MCP server" />
+</a>
+
 ## 🔧 Available Tools (Features)
 
 **Read-only Tools (Client Credentials):**


### PR DESCRIPTION
This PR adds a badge for the [reddit-mcp-server](https://glama.ai/mcp/servers/@jordanburke/reddit-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jordanburke/reddit-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jordanburke/reddit-mcp-server/badge" alt="reddit-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.