### PR TITLE
fix: make manifest author schema-compliant for MCPB

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,11 @@
   "version": "1.4.0",
   "description": "Browse Reddit and create content directly from Claude Desktop. The only Reddit MCP with full write operations.",
   "long_description": "Reddit MCP Server brings the full Reddit experience to Claude Desktop - not just reading, but writing too.\n\n**Key Features:**\n\n**Read Operations:**\n- Browse any subreddit with sorting options\n- Search Reddit content across all communities\n- Get user profiles with karma and activity\n- Fetch full post details including threaded comments\n- Discover trending subreddits\n\n**Write Operations (Unique!):**\n- Create new posts (text or link)\n- Reply to posts and comments\n- Edit your own posts and comments\n- Delete your own content\n\n**Why Choose Reddit MCP Server:**\n- **Full Write Support** - The only Reddit MCP that lets you post and interact\n- **Safe Mode** - Built-in spam protection to keep your account safe\n- **No API Keys Required** - Works instantly in anonymous mode\n- **Three Auth Tiers** - 10/60/100 requests per minute\n- **FastMCP Powered** - Modern, fast MCP implementation\n\n**Perfect for:**\n- Content creators and community managers\n- Market research and trend analysis\n- Automated posting with safeguards\n- Community engagement",
-  "author": "Jordan Burke <jordan.burke@gmail.com> (https://github.com/jordanburke)",
+  "author": {
+    "name": "Jordan Burke",
+    "email": "jordan.burke@gmail.com",
+    "url": "https://github.com/jordanburke"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jordanburke/reddit-mcp-server"


### PR DESCRIPTION
## Summary
- fix `manifest.json` so `author` is an object (`name`, `email`, `url`) instead of a string
- this matches MCPB manifest schema requirements

## Repro
`npx -y @anthropic-ai/mcpb@latest validate manifest.json` previously failed with:
- `author: Expected object, received string`

## Validation
- `npx -y @anthropic-ai/mcpb@latest validate manifest.json` now passes