### PR TITLE
fix: suppress dotenv stdout logs in stdio mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import type { BotDisclosureConfig, RedditAuthMode, RedditSafeMode, SafeModeConfi
 import { formatPostInfo, formatSubredditInfo, formatUserInfo } from "./utils/formatters"
 
 // Load environment variables
-dotenv.config()
+dotenv.config({ quiet: true })
 
 // Version injected at build time by tsdown
 declare const __VERSION__: string


### PR DESCRIPTION
## Summary
- update dotenv initialization to `dotenv.config({ quiet: true })`
- prevents dotenv v17 runtime tips/logs from being written to stdout

## Why
Claude Desktop stdio transport expects only JSON-RPC messages on stdout.
The dotenv runtime line (for example `[dotenv@17.3.1] injecting env...`) is not JSON and causes:
- `Invalid JSON-RPC message`
- immediate MCP server disconnects

## Validation
- built server and ran stdio startup with stdout/stderr capture
- stdout remained empty (`stdout_bytes=0`) while setup logs stayed on stderr