### PR TITLE
feat: subreddit rules + settable post flair (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,17 +15,19 @@ This is a Reddit MCP (Model Context Protocol) server that provides tools for int
 - `browse_subreddit` - Browse a subreddit or home feed by sort order (hot, new, top, rising, controversial); `time_filter` applies only to top/controversial
 - `get_user_info` - Get detailed information about a Reddit user
 - `get_subreddit_info` - Get subreddit details, stats, and community insights
+- `get_subreddit_rules` - Get a subreddit's posting rules (check before posting to avoid auto-removal)
 - `get_trending_subreddits` - Get currently trending/popular subreddits
 - `search_reddit` - Search for posts across Reddit with filters
 - `get_post_comments` - Get comments from a specific post with threading
 - `get_user_posts` - Get posts submitted by a specific user
 - `get_user_comments` - Get comments made by a specific user
+- `get_post_flairs` - List a subreddit's available link flairs (requires user creds; may 403 anonymously)
 
 ### Write Tools (User Credentials Required)
 
 **IMPORTANT**: These tools require both REDDIT_USERNAME and REDDIT_PASSWORD to be configured.
 
-- `create_post` - Create a new post in a subreddit (text or link)
+- `create_post` - Create a new post in a subreddit (text or link); accepts optional `flair_id`/`flair_text` (from `get_post_flairs`)
 - `reply_to_post` - Post a reply to an existing Reddit post or comment
 - `edit_post` - Edit your own Reddit post (self-text posts only, titles cannot be edited)
 - `edit_comment` - Edit your own Reddit comment

--- a/src/client/__tests__/reddit-client.test.ts
+++ b/src/client/__tests__/reddit-client.test.ts
@@ -1801,6 +1801,69 @@ describe("RedditClient", () => {
     })
   })
 
+  describe("getSubredditRules", () => {
+    const mockAuth = () =>
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "test-token", expires_in: 3600 }),
+      })
+
+    it("fetches and maps subreddit rules", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          rules: [
+            {
+              short_name: "No spam",
+              description: "Do not spam.",
+              kind: "all",
+              violation_reason: "Spam",
+              priority: 0,
+              created_utc: 1,
+            },
+            { short_name: "Flair required", description: "", kind: "link" },
+          ],
+        }),
+      })
+
+      const result = await client.getSubredditRules("programming")
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://oauth.reddit.com/r/programming/about/rules.json",
+        expect.any(Object),
+      )
+      expect(result.isRight()).toBe(true)
+      const rules = result.orThrow()
+      expect(rules).toHaveLength(2)
+      expect(rules[0].shortName).toBe("No spam")
+      expect(rules[0].kind).toBe("all")
+      expect(rules[0].violationReason).toBe("Spam")
+      expect(rules[1].shortName).toBe("Flair required")
+      expect(rules[1].kind).toBe("link")
+    })
+
+    it("returns an empty list when the subreddit has no rules", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ rules: [] }) })
+
+      const result = await client.getSubredditRules("programming")
+      expect(result.isRight()).toBe(true)
+      expect(result.orThrow()).toHaveLength(0)
+    })
+
+    it("returns a typed HttpError on a non-ok response", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+      const result = await client.getSubredditRules("ghost")
+      expect(result.isLeft()).toBe(true)
+      if (result.isLeft()) {
+        expect(result.value.message).toBe("Failed to get rules for r/ghost: HTTP 404")
+        expect(result.value._tag).toBe("HttpError")
+      }
+    })
+  })
+
   describe("rate-limit retry (429)", () => {
     const mockAuth = () =>
       mockFetch.mockResolvedValueOnce({

--- a/src/client/__tests__/reddit-client.test.ts
+++ b/src/client/__tests__/reddit-client.test.ts
@@ -1864,6 +1864,48 @@ describe("RedditClient", () => {
     })
   })
 
+  describe("getPostFlairs", () => {
+    const mockAuth = () =>
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "test-token", expires_in: 3600 }),
+      })
+
+    it("fetches and maps link flairs from the bare array response", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: "abc", text: "Discussion", type: "text", text_editable: false },
+          { id: "def", text: "Help", type: "richtext", text_editable: true },
+        ],
+      })
+
+      const result = await client.getPostFlairs("programming")
+      expect(mockFetch).toHaveBeenLastCalledWith(
+        "https://oauth.reddit.com/r/programming/api/link_flair_v2.json",
+        expect.any(Object),
+      )
+      expect(result.isRight()).toBe(true)
+      const flairs = result.orThrow()
+      expect(flairs).toHaveLength(2)
+      expect(flairs[0]).toEqual({ id: "abc", text: "Discussion", type: "text", textEditable: false })
+      expect(flairs[1].textEditable).toBe(true)
+    })
+
+    it("returns a typed HttpError when flairs are not accessible (e.g. 403)", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 403 })
+
+      const result = await client.getPostFlairs("programming")
+      expect(result.isLeft()).toBe(true)
+      if (result.isLeft()) {
+        expect(result.value.message).toBe("Failed to get post flairs for r/programming: HTTP 403")
+        expect(result.value._tag).toBe("HttpError")
+      }
+    })
+  })
+
   describe("rate-limit retry (429)", () => {
     const mockAuth = () =>
       mockFetch.mockResolvedValueOnce({

--- a/src/client/__tests__/reddit-client.test.ts
+++ b/src/client/__tests__/reddit-client.test.ts
@@ -703,6 +703,91 @@ describe("RedditClient", () => {
       expect(post.title).toBe("My New Post")
     })
 
+    it("includes flair_id and flair_text in the submit body when provided", async () => {
+      const mockSubmitResponse = { json: { data: { id: "p1" }, errors: [] } }
+      const mockPostData = [
+        {
+          data: {
+            children: [
+              {
+                data: {
+                  id: "p1",
+                  title: "T",
+                  author: "testuser",
+                  subreddit: "test",
+                  selftext: "C",
+                  url: "https://reddit.com/r/test/p1",
+                  score: 1,
+                  upvote_ratio: 1,
+                  num_comments: 0,
+                  created_utc: 1,
+                  over_18: false,
+                  spoiler: false,
+                  edited: false,
+                  is_self: true,
+                  link_flair_text: null,
+                  permalink: "/r/test/comments/p1/",
+                },
+              },
+            ],
+          },
+        },
+      ]
+
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: "t", expires_in: 3600 }) })
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockSubmitResponse })
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockPostData })
+
+      const result = await client.createPost("test", "T", "C", true, "flair-abc", "custom flair")
+      expect(result.isRight()).toBe(true)
+
+      const submitBody = new URLSearchParams(mockFetch.mock.calls[1][1].body as string)
+      expect(submitBody.get("flair_id")).toBe("flair-abc")
+      expect(submitBody.get("flair_text")).toBe("custom flair")
+    })
+
+    it("omits flair params when none are provided", async () => {
+      const mockSubmitResponse = { json: { data: { id: "p2" }, errors: [] } }
+      const mockPostData = [
+        {
+          data: {
+            children: [
+              {
+                data: {
+                  id: "p2",
+                  title: "T",
+                  author: "testuser",
+                  subreddit: "test",
+                  selftext: "C",
+                  url: "https://reddit.com/r/test/p2",
+                  score: 1,
+                  upvote_ratio: 1,
+                  num_comments: 0,
+                  created_utc: 1,
+                  over_18: false,
+                  spoiler: false,
+                  edited: false,
+                  is_self: true,
+                  link_flair_text: null,
+                  permalink: "/r/test/comments/p2/",
+                },
+              },
+            ],
+          },
+        },
+      ]
+
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: "t", expires_in: 3600 }) })
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockSubmitResponse })
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockPostData })
+
+      await client.createPost("test", "T", "C")
+
+      const submitBody = new URLSearchParams(mockFetch.mock.calls[1][1].body as string)
+      expect(submitBody.get("flair_id")).toBeNull()
+      expect(submitBody.get("flair_text")).toBeNull()
+    })
+
     it("should return Left when user is not authenticated for write", async () => {
       const clientReadOnly = new RedditClient({
         clientId: "test-client-id",

--- a/src/client/reddit-client.ts
+++ b/src/client/reddit-client.ts
@@ -23,6 +23,7 @@ import type {
   RedditApiPopularSubredditsResponse,
   RedditApiPostCommentsResponse,
   RedditApiPostData,
+  RedditApiRulesResponse,
   RedditApiSubmitResponse,
   RedditApiSubredditResponse,
   RedditApiUserResponse,
@@ -30,6 +31,7 @@ import type {
   RedditClientConfig,
   RedditComment,
   RedditPost,
+  RedditRule,
   RedditSubreddit,
   RedditUser,
   RetryConfig,
@@ -445,6 +447,28 @@ export class RedditClient {
         subredditType: data.subreddit_type,
         url: data.url,
       }
+    })
+
+    return attempt.toEither((error) => classifyRedditError(error, context))
+  }
+
+  async getSubredditRules(subreddit: string): Promise<Either<RedditError, readonly RedditRule[]>> {
+    const context = `Failed to get rules for r/${subreddit}`
+    const attempt = await Try.async(async (): Promise<readonly RedditRule[]> => {
+      const response = (await this.makeRequest(`/r/${subreddit}/about/rules.json`)).orThrow()
+      if (!response.ok) {
+        throw new HttpError(response.status, `${context}: HTTP ${response.status}`)
+      }
+
+      const json = (await response.json()) as RedditApiRulesResponse
+      return json.rules.map((rule) => ({
+        shortName: rule.short_name,
+        description: rule.description,
+        kind: rule.kind,
+        violationReason: rule.violation_reason,
+        priority: rule.priority,
+        createdUtc: rule.created_utc,
+      }))
     })
 
     return attempt.toEither((error) => classifyRedditError(error, context))

--- a/src/client/reddit-client.ts
+++ b/src/client/reddit-client.ts
@@ -614,6 +614,8 @@ export class RedditClient {
     title: string,
     content: string,
     isSelf: boolean = true,
+    flairId?: string,
+    flairText?: string,
   ): Promise<Either<RedditError, RedditPost>> {
     const attempt = await Try.async(async (): Promise<RedditPost> => {
       this.validateWriteAccess()
@@ -628,6 +630,12 @@ export class RedditClient {
       params.append("title", title)
       params.append(isSelf ? "text" : "url", finalContent)
       params.append("api_type", "json")
+      if (flairId !== undefined) {
+        params.append("flair_id", flairId)
+      }
+      if (flairText !== undefined) {
+        params.append("flair_text", flairText)
+      }
 
       const response = (
         await this.makeRequest("/api/submit", {

--- a/src/client/reddit-client.ts
+++ b/src/client/reddit-client.ts
@@ -19,6 +19,7 @@ import type {
   RedditApiCommentTreeData,
   RedditApiEditResponse,
   RedditApiInfoResponse,
+  RedditApiLinkFlairResponse,
   RedditApiListingResponse,
   RedditApiPopularSubredditsResponse,
   RedditApiPostCommentsResponse,
@@ -30,6 +31,7 @@ import type {
   RedditAuthMode,
   RedditClientConfig,
   RedditComment,
+  RedditFlair,
   RedditPost,
   RedditRule,
   RedditSubreddit,
@@ -468,6 +470,26 @@ export class RedditClient {
         violationReason: rule.violation_reason,
         priority: rule.priority,
         createdUtc: rule.created_utc,
+      }))
+    })
+
+    return attempt.toEither((error) => classifyRedditError(error, context))
+  }
+
+  async getPostFlairs(subreddit: string): Promise<Either<RedditError, readonly RedditFlair[]>> {
+    const context = `Failed to get post flairs for r/${subreddit}`
+    const attempt = await Try.async(async (): Promise<readonly RedditFlair[]> => {
+      const response = (await this.makeRequest(`/r/${subreddit}/api/link_flair_v2.json`)).orThrow()
+      if (!response.ok) {
+        throw new HttpError(response.status, `${context}: HTTP ${response.status}`)
+      }
+
+      const json = (await response.json()) as RedditApiLinkFlairResponse
+      return json.map((flair) => ({
+        id: flair.id,
+        text: flair.text,
+        type: flair.type,
+        textEditable: flair.text_editable,
       }))
     })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -893,6 +893,11 @@ server.addTool({
     title: z.string().describe("The post title"),
     content: z.string().describe("The post content (text for self posts, URL for link posts)"),
     is_self: z.boolean().default(true).describe("Whether this is a self post (text) or link post"),
+    flair_id: z
+      .string()
+      .optional()
+      .describe("Link flair template id (from get_post_flairs); many subreddits require a flair"),
+    flair_text: z.string().optional().describe("Custom flair text, only for flairs whose template is text-editable"),
   }),
   execute: async (args) => {
     const client = unwrapClient()
@@ -904,7 +909,14 @@ server.addTool({
       )
     }
 
-    const result = await client.createPost(args.subreddit, args.title, args.content, args.is_self)
+    const result = await client.createPost(
+      args.subreddit,
+      args.title,
+      args.content,
+      args.is_self,
+      args.flair_id,
+      args.flair_text,
+    )
     return result.fold(
       (err) => {
         // eslint-disable-next-line functype/prefer-either

--- a/src/index.ts
+++ b/src/index.ts
@@ -706,6 +706,43 @@ ${formattedSubreddit.description.full}
 })
 
 server.addTool({
+  name: "get_subreddit_rules",
+  description:
+    "Get a subreddit's posting rules. Useful to check requirements before creating a post to avoid auto-removal.",
+  parameters: z.object({
+    subreddit_name: z.string().describe("The subreddit name (without r/ prefix)"),
+  }),
+  execute: async (args) => {
+    const client = unwrapClient()
+
+    const result = await client.getSubredditRules(args.subreddit_name)
+    return result.fold(
+      (err) => {
+        // eslint-disable-next-line functype/prefer-either
+        throw new Error(`Failed to get subreddit rules: ${err.message}`)
+      },
+      (rules) => {
+        if (rules.length === 0) {
+          return `r/${args.subreddit_name} has no listed subreddit-specific rules.`
+        }
+
+        const ruleList = rules
+          .map((rule, index) => {
+            const applies = rule.kind === "all" ? "posts & comments" : `${rule.kind}s`
+            const detail = rule.description.trim() === "" ? "" : `\n${rule.description.trim()}`
+            return `### ${index + 1}. ${rule.shortName} _(applies to ${applies})_${detail}`
+          })
+          .join("\n\n")
+
+        return `# Posting Rules for r/${args.subreddit_name}
+
+${ruleList}`
+      },
+    )
+  },
+})
+
+server.addTool({
   name: "get_trending_subreddits",
   description: "Get a list of currently trending subreddits",
   parameters: z.object({}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -743,6 +743,44 @@ ${ruleList}`
 })
 
 server.addTool({
+  name: "get_post_flairs",
+  description:
+    "List the available link flairs for a subreddit (use a flair_id with create_post). Requires user credentials; many subreddits only expose flairs to members, so this may fail in anonymous mode.",
+  parameters: z.object({
+    subreddit_name: z.string().describe("The subreddit name (without r/ prefix)"),
+  }),
+  execute: async (args) => {
+    const client = unwrapClient()
+
+    const result = await client.getPostFlairs(args.subreddit_name)
+    return result.fold(
+      (err) => {
+        // eslint-disable-next-line functype/prefer-either
+        throw new Error(`Failed to get post flairs: ${err.message}`)
+      },
+      (flairs) => {
+        if (flairs.length === 0) {
+          return `r/${args.subreddit_name} has no selectable link flairs (or none are visible to this account).`
+        }
+
+        const flairList = flairs
+          .map((flair) => {
+            const editable = flair.textEditable === true ? " _(text editable)_" : ""
+            return `- ${flair.text}${editable} — \`flair_id: ${flair.id}\``
+          })
+          .join("\n")
+
+        return `# Available Link Flairs for r/${args.subreddit_name}
+
+${flairList}
+
+Pass the desired \`flair_id\` to \`create_post\`.`
+      },
+    )
+  },
+})
+
+server.addTool({
   name: "get_trending_subreddits",
   description: "Get a list of currently trending subreddits",
   parameters: z.object({}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,14 @@ export type RedditRule = {
   readonly createdUtc?: number
 }
 
+/** An available link flair template (from /r/{sr}/api/link_flair_v2). `id` is passed to create_post. */
+export type RedditFlair = {
+  readonly id: string
+  readonly text: string
+  readonly type?: string
+  readonly textEditable?: boolean
+}
+
 export type FormattedUserInfo = {
   readonly username: string
   readonly karma: {
@@ -287,6 +295,15 @@ export type RedditApiRulesResponse = {
   }>
   readonly [key: string]: unknown
 }
+
+// /r/{sr}/api/link_flair_v2 returns a bare JSON array of flair templates.
+export type RedditApiLinkFlairResponse = ReadonlyArray<{
+  readonly id: string
+  readonly text: string
+  readonly type?: string
+  readonly text_editable?: boolean
+  readonly [key: string]: unknown
+}>
 
 export type RedditApiCommentData = {
   readonly id: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,16 @@ export type Page<T> = {
   readonly before?: string
 }
 
+/** A subreddit posting rule (from /r/{sr}/about/rules). `kind` is "link" | "comment" | "all". */
+export type RedditRule = {
+  readonly shortName: string
+  readonly description: string
+  readonly kind: string
+  readonly violationReason?: string
+  readonly priority?: number
+  readonly createdUtc?: number
+}
+
 export type FormattedUserInfo = {
   readonly username: string
   readonly karma: {
@@ -263,6 +273,19 @@ export type RedditApiListingResponse<T> = {
     }>
     readonly [key: string]: unknown
   }
+}
+
+export type RedditApiRulesResponse = {
+  readonly rules: ReadonlyArray<{
+    readonly short_name: string
+    readonly description: string
+    readonly kind: string
+    readonly violation_reason?: string
+    readonly priority?: number
+    readonly created_utc?: number
+    readonly [key: string]: unknown
+  }>
+  readonly [key: string]: unknown
 }
 
 export type RedditApiCommentData = {


### PR DESCRIPTION
Closes #11.

Improves write success — the most common failure is auto-removal for missing flair / rule violations. Three commits:

### 1. `get_subreddit_rules`
`GET /r/{sr}/about/rules.json` → typed `RedditRule[]` (`shortName`, `description`, `kind`, …). Public endpoint; works in any auth mode. Lets an agent check requirements before posting.

### 2. `get_post_flairs`
`GET /r/{sr}/api/link_flair_v2` (bare JSON array) → typed `RedditFlair[]` (`id`, `text`, `type?`, `textEditable?`); the tool surfaces each `flair_id`.
**Auth caveat (documented):** link-flair listing needs the `flair` scope and many subreddits only expose flairs to members, so it commonly **403s in anonymous mode** — surfaced as a typed `HttpError`.

### 3. `create_post` flair
`create_post` accepts optional `flair_id`/`flair_text` (append to the submit request); `flair_text` only applies to text-editable templates.

### Tests / validation
New client tests for each part (rules mapping/empty/HTTP error; flair bare-array mapping/403; flair params present-vs-omitted in the submit body). `pnpm validate` clean: lint 0, tsc clean, **115 tests**, build ✓.

### Out of scope
Voting/DM/crosspost behaviors (Responsible Builder Policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
