### PR TITLE
feat: get_more_comments — expand truncated comment threads (#12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ This is a Reddit MCP (Model Context Protocol) server that provides tools for int
 - `get_trending_subreddits` - Get currently trending/popular subreddits
 - `search_reddit` - Search for posts across Reddit with filters
 - `get_post_comments` - Get comments from a specific post with threading
+- `get_more_comments` - Expand truncated "load more" comment stubs via /api/morechildren
 - `get_user_posts` - Get posts submitted by a specific user
 - `get_user_comments` - Get comments made by a specific user
 - `get_post_flairs` - List a subreddit's available link flairs (requires user creds; may 403 anonymously)

--- a/src/client/__tests__/reddit-client.test.ts
+++ b/src/client/__tests__/reddit-client.test.ts
@@ -1949,6 +1949,84 @@ describe("RedditClient", () => {
     })
   })
 
+  describe("getMoreComments", () => {
+    const mockAuth = () =>
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "test-token", expires_in: 3600 }),
+      })
+
+    it("expands a 'more' stub into a flat list of comments and forwards ids", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          json: {
+            data: {
+              things: [
+                {
+                  kind: "t1",
+                  data: {
+                    id: "c1",
+                    author: "alice",
+                    body: "hello",
+                    score: 5,
+                    controversiality: 0,
+                    subreddit: "test",
+                    created_utc: 1,
+                    edited: false,
+                    is_submitter: true,
+                    permalink: "/r/test/comments/p1/c1",
+                    parent_id: "t3_p1",
+                  },
+                },
+                { kind: "more", data: { id: "x", children: ["c9"] } },
+              ],
+            },
+          },
+        }),
+      })
+
+      const result = await client.getMoreComments("p1", ["c1", "c2"])
+
+      const lastUrl = mockFetch.mock.calls[mockFetch.mock.calls.length - 1][0]
+      expect(lastUrl).toContain("/api/morechildren?")
+      expect(lastUrl).toContain("link_id=t3_p1")
+      expect(lastUrl).toContain("children=c1%2Cc2")
+
+      expect(result.isRight()).toBe(true)
+      const comments = result.orThrow()
+      expect(comments).toHaveLength(1) // the "more" stub is filtered out
+      expect(comments[0].id).toBe("c1")
+      expect(comments[0].author).toBe("alice")
+      expect(comments[0].parentId).toBe("t3_p1")
+      expect(comments[0].isSubmitter).toBe(true)
+    })
+
+    it("does not double-prefix an already-prefixed link id", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ json: { data: { things: [] } } }) })
+
+      await client.getMoreComments("t3_p1", ["c1"])
+
+      const lastUrl = mockFetch.mock.calls[mockFetch.mock.calls.length - 1][0]
+      expect(lastUrl).toContain("link_id=t3_p1")
+      expect(lastUrl).not.toContain("t3_t3_")
+    })
+
+    it("returns a typed HttpError on a non-ok response", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 400 })
+
+      const result = await client.getMoreComments("p1", ["c1"])
+      expect(result.isLeft()).toBe(true)
+      if (result.isLeft()) {
+        expect(result.value.message).toBe("Failed to expand comments for t3_p1: HTTP 400")
+        expect(result.value._tag).toBe("HttpError")
+      }
+    })
+  })
+
   describe("getPostFlairs", () => {
     const mockAuth = () =>
       mockFetch.mockResolvedValueOnce({

--- a/src/client/reddit-client.ts
+++ b/src/client/reddit-client.ts
@@ -21,6 +21,7 @@ import type {
   RedditApiInfoResponse,
   RedditApiLinkFlairResponse,
   RedditApiListingResponse,
+  RedditApiMoreChildrenResponse,
   RedditApiPopularSubredditsResponse,
   RedditApiPostCommentsResponse,
   RedditApiPostData,
@@ -949,6 +950,52 @@ export class RedditClient {
         return { post, comments }
       },
     )
+
+    return attempt.toEither((error) => classifyRedditError(error, context))
+  }
+
+  // Expand "load more" comment stubs via /api/morechildren. `commentIds` are the ids from a
+  // `more` node returned by getPostComments. Returns a flat list of the expanded comments.
+  async getMoreComments(
+    linkId: string,
+    commentIds: readonly string[],
+  ): Promise<Either<RedditError, readonly RedditComment[]>> {
+    const fullLinkId = linkId.startsWith("t3_") ? linkId : `t3_${linkId}`
+    const context = `Failed to expand comments for ${fullLinkId}`
+    const params = new URLSearchParams({
+      api_type: "json",
+      link_id: fullLinkId,
+      children: commentIds.join(","),
+    })
+
+    const attempt = await Try.async(async (): Promise<readonly RedditComment[]> => {
+      const response = (await this.makeRequest(`/api/morechildren?${params}`)).orThrow()
+      if (!response.ok) {
+        throw new HttpError(response.status, `${context}: HTTP ${response.status}`)
+      }
+
+      const json = (await response.json()) as RedditApiMoreChildrenResponse
+      const things = json.json.data?.things ?? []
+      return things
+        .filter((thing) => thing.kind === "t1" && thing.data.body !== undefined)
+        .map((thing) => {
+          const comment = thing.data
+          return {
+            id: comment.id,
+            author: comment.author,
+            body: comment.body ?? "",
+            score: comment.score,
+            controversiality: comment.controversiality,
+            subreddit: comment.subreddit,
+            submissionTitle: comment.link_title ?? "",
+            createdUtc: comment.created_utc,
+            edited: Boolean(comment.edited),
+            isSubmitter: comment.is_submitter,
+            permalink: comment.permalink,
+            parentId: comment.parent_id,
+          }
+        })
+    })
 
     return attempt.toEither((error) => classifyRedditError(error, context))
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1194,6 +1194,48 @@ ${comment.body}
   },
 })
 
+server.addTool({
+  name: "get_more_comments",
+  description:
+    "Expand truncated 'load more comments' stubs in a thread. Pass the post's link id and the comment ids from a 'more' node (returned by get_post_comments) to fetch those comments.",
+  parameters: z.object({
+    link_id: z.string().describe("The post (link) id, with or without the t3_ prefix"),
+    comment_ids: z.array(z.string()).min(1).describe("Comment ids to expand (from a 'more' node)"),
+  }),
+  execute: async (args) => {
+    const client = unwrapClient()
+
+    const result = await client.getMoreComments(args.link_id, args.comment_ids)
+    return result.fold(
+      (err) => {
+        // eslint-disable-next-line functype/prefer-either
+        throw new Error(`Failed to expand comments: ${err.message}`)
+      },
+      (comments) => {
+        if (comments.length === 0) {
+          return "No additional comments were returned for those ids."
+        }
+
+        const commentList = comments
+          .map((comment, index) => {
+            const truncated = comment.body.length > 300 ? `${comment.body.substring(0, 300)}...` : comment.body
+            const flags = [...(comment.edited ? ["*(edited)*"] : []), ...(comment.isSubmitter ? ["**OP**"] : [])]
+            return `### ${index + 1}. u/${comment.author} ${flags.join(" ")}
+> ${truncated}
+
+- Score: ${comment.score.toLocaleString()}
+- Link: https://reddit.com${comment.permalink}`
+          })
+          .join("\n\n")
+
+        return `# Expanded Comments (${comments.length})
+
+${commentList}`
+      },
+    )
+  },
+})
+
 // Initialize and start server
 async function main() {
   await setupRedditClient()

--- a/src/types.ts
+++ b/src/types.ts
@@ -357,6 +357,19 @@ export type RedditApiCommentResponse = {
   }
 }
 
+// /api/morechildren returns a flat list of comment "things" (and possibly further "more" stubs).
+export type RedditApiMoreChildrenResponse = {
+  readonly json: {
+    readonly errors?: ReadonlyArray<readonly [string, string, string?]>
+    readonly data?: {
+      readonly things?: ReadonlyArray<{
+        readonly kind: string
+        readonly data: RedditApiCommentTreeData
+      }>
+    }
+  }
+}
+
 // Reddit API Edit Response (for editPost)
 export type RedditApiEditResponse = {
   readonly json: {


### PR DESCRIPTION
Closes #12.

`get_post_comments` returns only the initial tree; deep threads end in "load more" stubs. This adds `get_more_comments` to expand them.

- **Client `getMoreComments(linkId, commentIds)`** → `GET /api/morechildren` (`api_type=json`, `link_id`, `children`), returning a flat `RedditComment[]`. Filters out nested `more` stubs and bodyless entries; normalizes the `t3_` prefix.
- **MCP tool** `get_more_comments(link_id, comment_ids)` renders the expanded comments.

### Tests / validation
Client tests: expands a `more` stub + forwards the ids (`children=c1,c2`), no double-prefix on an already-`t3_`-prefixed id, typed `HttpError` on non-ok. `pnpm validate` clean: lint 0, tsc clean, **118 tests**, build ✓.

### Out of scope
Voting/DM/crosspost behaviors (Responsible Builder Policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
