### PR TITLE
feat: authenticated-user read tools — get_me, get_my_overview, get_my_saved (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This is a Reddit MCP (Model Context Protocol) server that provides tools for int
 - `get_top_posts` - Get top posts from a subreddit or home feed
 - `browse_subreddit` - Browse a subreddit or home feed by sort order (hot, new, top, rising, controversial); `time_filter` applies only to top/controversial
 - `get_user_info` - Get detailed information about a Reddit user
+- `get_me` - Get the authenticated user's own account info (requires user credentials)
 - `get_subreddit_info` - Get subreddit details, stats, and community insights
 - `get_subreddit_rules` - Get a subreddit's posting rules (check before posting to avoid auto-removal)
 - `get_trending_subreddits` - Get currently trending/popular subreddits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ This is a Reddit MCP (Model Context Protocol) server that provides tools for int
 - `browse_subreddit` - Browse a subreddit or home feed by sort order (hot, new, top, rising, controversial); `time_filter` applies only to top/controversial
 - `get_user_info` - Get detailed information about a Reddit user
 - `get_me` - Get the authenticated user's own account info (requires user credentials)
+- `get_my_overview` - Get your own recent posts and comments (requires user credentials)
+- `get_my_saved` - Get your saved posts and comments (requires user credentials; private)
 - `get_subreddit_info` - Get subreddit details, stats, and community insights
 - `get_subreddit_rules` - Get a subreddit's posting rules (check before posting to avoid auto-removal)
 - `get_trending_subreddits` - Get currently trending/popular subreddits

--- a/src/client/__tests__/reddit-client.test.ts
+++ b/src/client/__tests__/reddit-client.test.ts
@@ -1932,6 +1932,101 @@ describe("RedditClient", () => {
     })
   })
 
+  describe("getMyOverview / getMySaved", () => {
+    const mockAuth = () =>
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "test-token", expires_in: 3600 }),
+      })
+    const mixedListing = {
+      data: {
+        children: [
+          {
+            kind: "t3",
+            data: {
+              id: "post1",
+              title: "A post",
+              author: "testuser",
+              subreddit: "s",
+              selftext: "",
+              url: "https://reddit.com",
+              score: 9,
+              upvote_ratio: 1,
+              num_comments: 2,
+              created_utc: 1,
+              over_18: false,
+              spoiler: false,
+              edited: false,
+              is_self: true,
+              link_flair_text: null,
+              permalink: "/r/s/comments/post1/",
+            },
+          },
+          {
+            kind: "t1",
+            data: {
+              id: "c1",
+              author: "testuser",
+              body: "a comment",
+              score: 3,
+              controversiality: 0,
+              subreddit: "s",
+              created_utc: 1,
+              edited: false,
+              is_submitter: false,
+              permalink: "/r/s/comments/post1/c1",
+              parent_id: "t3_post1",
+            },
+          },
+        ],
+        after: "t1_next",
+        before: null,
+      },
+    }
+
+    it("splits overview into posts and comments and surfaces the cursor", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mixedListing })
+
+      const result = await client.getMyOverview({ limit: 10 })
+      const lastUrl = mockFetch.mock.calls[mockFetch.mock.calls.length - 1][0]
+      expect(lastUrl).toContain("/user/testuser/overview.json")
+
+      expect(result.isRight()).toBe(true)
+      const content = result.orThrow()
+      expect(content.posts).toHaveLength(1)
+      expect(content.posts[0].id).toBe("post1")
+      expect(content.comments).toHaveLength(1)
+      expect(content.comments[0].id).toBe("c1")
+      expect(content.after).toBe("t1_next")
+    })
+
+    it("getMySaved hits the saved endpoint", async () => {
+      mockAuth()
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mixedListing })
+
+      await client.getMySaved({})
+      const lastUrl = mockFetch.mock.calls[mockFetch.mock.calls.length - 1][0]
+      expect(lastUrl).toContain("/user/testuser/saved.json")
+    })
+
+    it("returns NotAuthenticatedError when no username is configured", async () => {
+      const readOnly = new RedditClient({
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        userAgent: "TestApp/1.0.0",
+      })
+
+      const result = await readOnly.getMySaved({})
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(result.isLeft()).toBe(true)
+      if (result.isLeft()) {
+        expect(result.value._tag).toBe("NotAuthenticatedError")
+        expect(result.value.message).toBe("Fetching saved content requires REDDIT_USERNAME")
+      }
+    })
+  })
+
   describe("getSubredditRules", () => {
     const mockAuth = () =>
       mockFetch.mockResolvedValueOnce({

--- a/src/client/__tests__/reddit-client.test.ts
+++ b/src/client/__tests__/reddit-client.test.ts
@@ -1886,6 +1886,52 @@ describe("RedditClient", () => {
     })
   })
 
+  describe("getMe", () => {
+    it("fetches the authenticated user from the top-level /api/v1/me shape", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "test-token", expires_in: 3600 }),
+      })
+      // /api/v1/me returns account fields at the ROOT (no data wrapper)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          name: "testuser",
+          id: "abc",
+          comment_karma: 10,
+          link_karma: 20,
+          is_mod: false,
+          is_gold: true,
+          is_employee: false,
+          created_utc: 123,
+        }),
+      })
+
+      const result = await client.getMe()
+      expect(mockFetch).toHaveBeenLastCalledWith("https://oauth.reddit.com/api/v1/me", expect.any(Object))
+      expect(result.isRight()).toBe(true)
+      const me = result.orThrow()
+      expect(me.name).toBe("testuser")
+      expect(me.totalKarma).toBe(30) // computed from comment + link when total_karma absent
+      expect(me.profileUrl).toBe("https://reddit.com/user/testuser")
+    })
+
+    it("returns a typed HttpError when not authenticated (403)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "test-token", expires_in: 3600 }),
+      })
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 403 })
+
+      const result = await client.getMe()
+      expect(result.isLeft()).toBe(true)
+      if (result.isLeft()) {
+        expect(result.value.message).toBe("Failed to get authenticated user info: HTTP 403")
+        expect(result.value._tag).toBe("HttpError")
+      }
+    })
+  })
+
   describe("getSubredditRules", () => {
     const mockAuth = () =>
       mockFetch.mockResolvedValueOnce({

--- a/src/client/reddit-client.ts
+++ b/src/client/reddit-client.ts
@@ -40,6 +40,7 @@ import type {
   RedditUser,
   RetryConfig,
   SafeModeConfig,
+  UserContent,
 } from "../types"
 import type { RedditError } from "./errors"
 import {
@@ -426,6 +427,71 @@ export class RedditClient {
     })
 
     return attempt.toEither((error) => classifyRedditError(error, context))
+  }
+
+  // Fetch + split a mixed user listing (saved/overview) into posts (t3) and comments (t1).
+  private async getUserContent(path: string, context: string): Promise<Either<RedditError, UserContent>> {
+    const attempt = await Try.async(async (): Promise<UserContent> => {
+      const response = (await this.makeRequest(path)).orThrow()
+      if (!response.ok) {
+        throw new HttpError(response.status, `${context}: HTTP ${response.status}`)
+      }
+
+      const json = (await response.json()) as RedditApiListingResponse<RedditApiPostData | RedditApiCommentTreeData>
+      const posts = json.data.children
+        .filter((child) => child.kind === "t3")
+        .map((child) => parsePostData(child.data as RedditApiPostData))
+      const comments = json.data.children
+        .filter((child) => child.kind === "t1")
+        .map((child) => {
+          const comment = child.data as RedditApiCommentTreeData
+          return {
+            id: comment.id,
+            author: comment.author,
+            body: comment.body ?? "",
+            score: comment.score,
+            controversiality: comment.controversiality,
+            subreddit: comment.subreddit,
+            submissionTitle: comment.link_title ?? "",
+            createdUtc: comment.created_utc,
+            edited: Boolean(comment.edited),
+            isSubmitter: comment.is_submitter,
+            permalink: comment.permalink,
+            parentId: comment.parent_id,
+          }
+        })
+      return { posts, comments, ...listingCursor(json.data) }
+    })
+
+    return attempt.toEither((error) => classifyRedditError(error, context))
+  }
+
+  async getMyOverview(
+    options: { readonly limit?: number; readonly after?: string } = {},
+  ): Promise<Either<RedditError, UserContent>> {
+    if (this.username === undefined) {
+      return Left(new NotAuthenticatedError("Fetching your overview requires REDDIT_USERNAME"))
+    }
+    const { limit = 25, after } = options
+    const params = new URLSearchParams({ limit: limit.toString() })
+    if (after !== undefined) {
+      params.set("after", after)
+    }
+    return this.getUserContent(`/user/${this.username}/overview.json?${params}`, "Failed to get your overview")
+  }
+
+  async getMySaved(
+    options: { readonly limit?: number; readonly after?: string } = {},
+  ): Promise<Either<RedditError, UserContent>> {
+    if (this.username === undefined) {
+      return Left(new NotAuthenticatedError("Fetching saved content requires REDDIT_USERNAME"))
+    }
+    const { limit = 25, after } = options
+    const params = new URLSearchParams({ limit: limit.toString() })
+    if (after !== undefined) {
+      params.set("after", after)
+    }
+    return this.getUserContent(`/user/${this.username}/saved.json?${params}`, "Failed to get saved content")
   }
 
   // The authenticated user's own account (requires user credentials — /api/v1/me needs identity).

--- a/src/client/reddit-client.ts
+++ b/src/client/reddit-client.ts
@@ -21,6 +21,7 @@ import type {
   RedditApiInfoResponse,
   RedditApiLinkFlairResponse,
   RedditApiListingResponse,
+  RedditApiMeResponse,
   RedditApiMoreChildrenResponse,
   RedditApiPopularSubredditsResponse,
   RedditApiPostCommentsResponse,
@@ -410,6 +411,33 @@ export class RedditClient {
       const json = (await response.json()) as RedditApiUserResponse
       const { data } = json
 
+      return {
+        name: data.name,
+        id: data.id,
+        commentKarma: data.comment_karma,
+        linkKarma: data.link_karma,
+        totalKarma: data.total_karma ?? data.comment_karma + data.link_karma,
+        isMod: data.is_mod,
+        isGold: data.is_gold,
+        isEmployee: data.is_employee,
+        createdUtc: data.created_utc,
+        profileUrl: `https://reddit.com/user/${data.name}`,
+      }
+    })
+
+    return attempt.toEither((error) => classifyRedditError(error, context))
+  }
+
+  // The authenticated user's own account (requires user credentials — /api/v1/me needs identity).
+  async getMe(): Promise<Either<RedditError, RedditUser>> {
+    const context = "Failed to get authenticated user info"
+    const attempt = await Try.async(async (): Promise<RedditUser> => {
+      const response = (await this.makeRequest("/api/v1/me")).orThrow()
+      if (!response.ok) {
+        throw new HttpError(response.status, `${context}: HTTP ${response.status}`)
+      }
+
+      const data = (await response.json()) as RedditApiMeResponse
       return {
         name: data.name,
         id: data.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import type {
   RedditSafeMode,
   RetryConfig,
   SafeModeConfig,
+  UserContent,
 } from "./types"
 import { formatPostInfo, formatSubredditInfo, formatUserInfo } from "./utils/formatters"
 
@@ -94,6 +95,33 @@ function nextPageHint(after?: string): string {
     () => "",
     (cursor) => `\n\n---\nMore results available — call again with after="${cursor}" for the next page.`,
   )
+}
+
+// Render a mixed posts+comments listing (saved / overview).
+function formatUserContent(heading: string, content: UserContent): string {
+  const postsSection =
+    content.posts.length === 0
+      ? ""
+      : `## Posts (${content.posts.length})\n${content.posts
+          .map(
+            (post, index) =>
+              `${index + 1}. ${post.title} — r/${post.subreddit}, score ${post.score.toLocaleString()} — https://reddit.com${post.permalink}`,
+          )
+          .join("\n")}\n\n`
+
+  const commentsSection =
+    content.comments.length === 0
+      ? ""
+      : `## Comments (${content.comments.length})\n${content.comments
+          .map((comment, index) => {
+            const body = comment.body.length > 200 ? `${comment.body.substring(0, 200)}...` : comment.body
+            return `${index + 1}. in r/${comment.subreddit}: ${body} — https://reddit.com${comment.permalink}`
+          })
+          .join("\n")}\n\n`
+
+  const empty = content.posts.length === 0 && content.comments.length === 0 ? "No items found.\n\n" : ""
+
+  return `# ${heading}\n\n${postsSection}${commentsSection}${empty}`.trimEnd() + nextPageHint(content.after)
 }
 
 // Initialize Reddit client
@@ -381,6 +409,50 @@ server.addTool({
 - Account Created: ${formattedUser.accountCreated}
 - Profile URL: ${formattedUser.profileUrl}`
       },
+    )
+  },
+})
+
+server.addTool({
+  name: "get_my_overview",
+  description:
+    "Get your own recent activity (posts and comments combined). Requires user credentials (REDDIT_USERNAME/REDDIT_PASSWORD).",
+  parameters: z.object({
+    limit: z.number().min(1).max(100).default(25).describe("Number of items to retrieve"),
+    after: z.string().optional().describe("Pagination cursor: pass the `after` value from a previous page"),
+  }),
+  execute: async (args) => {
+    const client = unwrapClient()
+
+    const result = await client.getMyOverview({ limit: args.limit, after: args.after })
+    return result.fold(
+      (err) => {
+        // eslint-disable-next-line functype/prefer-either
+        throw new Error(`Failed to get your overview: ${err.message}`)
+      },
+      (content) => formatUserContent("Your Overview", content),
+    )
+  },
+})
+
+server.addTool({
+  name: "get_my_saved",
+  description:
+    "Get your saved posts and comments. Requires user credentials (REDDIT_USERNAME/REDDIT_PASSWORD); saved content is private.",
+  parameters: z.object({
+    limit: z.number().min(1).max(100).default(25).describe("Number of items to retrieve"),
+    after: z.string().optional().describe("Pagination cursor: pass the `after` value from a previous page"),
+  }),
+  execute: async (args) => {
+    const client = unwrapClient()
+
+    const result = await client.getMySaved({ limit: args.limit, after: args.after })
+    return result.fold(
+      (err) => {
+        // eslint-disable-next-line functype/prefer-either
+        throw new Error(`Failed to get saved content: ${err.message}`)
+      },
+      (content) => formatUserContent("Your Saved Content", content),
     )
   },
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -353,6 +353,39 @@ server.addTool({
 })
 
 server.addTool({
+  name: "get_me",
+  description:
+    "Get the authenticated user's own account info (karma, account status). Requires user credentials (REDDIT_USERNAME/REDDIT_PASSWORD); fails in anonymous mode.",
+  parameters: z.object({}),
+  execute: async () => {
+    const client = unwrapClient()
+
+    const result = await client.getMe()
+    return result.fold(
+      (err) => {
+        // eslint-disable-next-line functype/prefer-either
+        throw new Error(`Failed to get authenticated user: ${err.message}`)
+      },
+      (user) => {
+        const formattedUser = formatUserInfo(user)
+
+        return `# Your Account: u/${formattedUser.username}
+
+## Profile Overview
+- Username: u/${formattedUser.username}
+- Karma:
+  - Comment Karma: ${formattedUser.karma.commentKarma.toLocaleString()}
+  - Post Karma: ${formattedUser.karma.postKarma.toLocaleString()}
+  - Total Karma: ${formattedUser.karma.totalKarma.toLocaleString()}
+- Account Status: ${formattedUser.accountStatus.join(", ")}
+- Account Created: ${formattedUser.accountCreated}
+- Profile URL: ${formattedUser.profileUrl}`
+      },
+    )
+  },
+})
+
+server.addTool({
   name: "get_user_posts",
   description: "Get recent posts by a Reddit user with sorting and filtering options",
   parameters: z.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,17 @@ export type Page<T> = {
   readonly before?: string
 }
 
+/**
+ * A mixed page of a user's posts and comments (saved / overview listings), split by kind, plus
+ * the pagination cursor.
+ */
+export type UserContent = {
+  readonly posts: readonly RedditPost[]
+  readonly comments: readonly RedditComment[]
+  readonly after?: string
+  readonly before?: string
+}
+
 /** A subreddit posting rule (from /r/{sr}/about/rules). `kind` is "link" | "comment" | "all". */
 export type RedditRule = {
   readonly shortName: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,6 +220,21 @@ export type FormattedCommentInfo = {
 }
 
 // Reddit API Response Types (Raw API structures)
+
+// /api/v1/me returns the account fields at the top level (no "data" wrapper).
+export type RedditApiMeResponse = {
+  readonly name: string
+  readonly id: string
+  readonly comment_karma: number
+  readonly link_karma: number
+  readonly total_karma?: number
+  readonly is_mod: boolean
+  readonly is_gold: boolean
+  readonly is_employee: boolean
+  readonly created_utc: number
+  readonly [key: string]: unknown
+}
+
 export type RedditApiUserResponse = {
   readonly data: {
     readonly name: string


### PR DESCRIPTION
Closes #13.

Adds read tools for the authenticated user's own context. Two commits:

### 1. `get_me`
`GET /api/v1/me` → `RedditUser`. Note: `/api/v1/me` returns account fields at the **top level** (no `data` wrapper, unlike `/user/X/about`). Requires user credentials; typed `HttpError(403)` in anonymous mode.

### 2. `get_my_overview` + `get_my_saved`
`/user/{me}/overview` and `/user/{me}/saved` (using the configured `REDDIT_USERNAME`). Both return a typed **`UserContent`** (`{ posts, comments, after?, before? }`) — a shared `getUserContent` helper splits the mixed listing by kind (`t3` posts / `t1` comments) and surfaces the pagination cursor. Returns `NotAuthenticatedError` when no username is configured.

### Tests / validation
Client tests: `get_me` top-level parse + 403; overview splits posts/comments + cursor; saved endpoint; `NotAuthenticatedError` without a username. `pnpm validate` clean: lint 0, tsc clean, **123 tests**, build ✓.

### Out of scope
Inbox/DMs (Responsible Builder Policy); voting/crosspost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
