### PR TITLE
fix(client): get_me requires REDDIT_USERNAME (avoid read-only crash)

### DIFF
--- a/src/client/__tests__/reddit-client.test.ts
+++ b/src/client/__tests__/reddit-client.test.ts
@@ -1930,6 +1930,24 @@ describe("RedditClient", () => {
         expect(result.value._tag).toBe("HttpError")
       }
     })
+
+    it("returns NotAuthenticatedError (no request) when no username is configured", async () => {
+      // Read-only mode: /api/v1/me app-only returns no karma fields, which previously crashed
+      // the formatter. get_me must short-circuit like the other authenticated-user tools.
+      const readOnly = new RedditClient({
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+        userAgent: "TestApp/1.0.0",
+      })
+
+      const result = await readOnly.getMe()
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(result.isLeft()).toBe(true)
+      if (result.isLeft()) {
+        expect(result.value._tag).toBe("NotAuthenticatedError")
+        expect(result.value.message).toBe("Fetching your account requires REDDIT_USERNAME")
+      }
+    })
   })
 
   describe("getMyOverview / getMySaved", () => {

--- a/src/client/reddit-client.ts
+++ b/src/client/reddit-client.ts
@@ -496,6 +496,9 @@ export class RedditClient {
 
   // The authenticated user's own account (requires user credentials — /api/v1/me needs identity).
   async getMe(): Promise<Either<RedditError, RedditUser>> {
+    if (this.username === undefined) {
+      return Left(new NotAuthenticatedError("Fetching your account requires REDDIT_USERNAME"))
+    }
     const context = "Failed to get authenticated user info"
     const attempt = await Try.async(async (): Promise<RedditUser> => {
       const response = (await this.makeRequest("/api/v1/me")).orThrow()


### PR DESCRIPTION
## Bug
In read-only mode (no `REDDIT_USERNAME`), `get_me` crashed with `Cannot read properties of undefined (reading 'toLocaleString')`.

`getMe` had no credential guard (unlike `get_my_overview`/`get_my_saved`). It called `/api/v1/me` app-only, got a `200` with **no karma fields**, mapped them to `undefined`, and the tool formatter blew up on `karma.commentKarma.toLocaleString()`.

## Fix
Guard on `this.username` and return `NotAuthenticatedError` up front — consistent with the other authenticated-user tools. No request is made when unauthenticated.

## How it was found
A live smoke test against a read-only server (caught what the unit test missed — it mocked a *complete* `/api/v1/me` body). Added a regression test asserting `getMe` short-circuits to `NotAuthenticatedError` (and makes no fetch) when no username is configured.

`pnpm validate` clean: lint 0, tsc clean, **124 tests**, build ✓.
