### PR TITLE
release: 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.0] - 2026-06-22
+
+### Added
+
+- Cursor pagination (`after`) on listing tools: `get_top_posts`, `browse_subreddit`, `search_reddit`, `get_user_posts`, `get_user_comments` (tools render a "more results" hint with the next cursor)
+- Rate-limit resilience: transparent HTTP 429 retry honoring `Retry-After`/`x-ratelimit-reset` with exponential-backoff fallback (`REDDIT_MAX_RETRIES`, default 3)
+- `get_subreddit_rules` — a subreddit's posting rules
+- `get_post_flairs` — available link flairs; `create_post` now accepts `flair_id`/`flair_text`
+- `get_more_comments` — expand truncated "load more" comment stubs via `/api/morechildren`
+- Authenticated-user reads: `get_me`, `get_my_overview`, `get_my_saved`
+
+### Changed
+
+- Client error channel is now a typed discriminated ADT (`Either<RedditError, T>` — `HttpError`/`NotFoundError`/`ApiError`/`ValidationError`/`NotAuthenticatedError`/`UnknownError`) built on functype `Try`, replacing bare `Error`; observable error messages are unchanged
+- Removed an unused duplicate set of tool modules (`src/tools/*`); tools are defined inline in the server entry
+
+### Fixed
+
+- `get_me` no longer crashes in read-only mode — it now returns a clear `NotAuthenticatedError` when `REDDIT_USERNAME` is not configured
+- Flaky test failures caused by a duplicate `vi.mock` hoist race
+
 ## [1.0.7] - 2025-06-27
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "reddit-mcp-server",
   "display_name": "Reddit MCP Server",
-  "version": "1.4.8",
+  "version": "1.5.0",
   "description": "Browse Reddit and create content directly from Claude Desktop. The only Reddit MCP with full write operations.",
   "long_description": "Reddit MCP Server brings the full Reddit experience to Claude Desktop - not just reading, but writing too.\n\n**Key Features:**\n\n**Read Operations:**\n- Browse any subreddit with sorting options\n- Search Reddit content across all communities\n- Get user profiles with karma and activity\n- Fetch full post details including threaded comments\n- Discover trending subreddits\n\n**Write Operations (Unique!):**\n- Create new posts (text or link)\n- Reply to posts and comments\n- Edit your own posts and comments\n- Delete your own content\n\n**Why Choose Reddit MCP Server:**\n- **Full Write Support** - The only Reddit MCP that lets you post and interact\n- **Safe Mode** - Built-in spam protection to keep your account safe\n- **No API Keys Required** - Works instantly in anonymous mode\n- **Three Auth Tiers** - 10/60/100 requests per minute\n- **FastMCP Powered** - Modern, fast MCP implementation\n\n**Perfect for:**\n- Content creators and community managers\n- Market research and trend analysis\n- Automated posting with safeguards\n- Community engagement",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit-mcp-server",
-  "version": "1.4.8",
+  "version": "1.5.0",
   "description": "A Model Context Protocol (MCP) server for Reddit with full read AND write operations - create posts, reply, edit, and delete content.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/jordanburke/reddit-mcp-server",
     "source": "github"
   },
-  "version": "1.4.8",
+  "version": "1.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "reddit-mcp-server",
-      "version": "1.4.8",
+      "version": "1.5.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Lockstep version bump to **1.5.0** across `package.json`, `server.json` (both `.version` and `.packages[0].version`), and `manifest.json`, plus a CHANGELOG entry. `pnpm check:versions` passes.

### Included since 1.4.8
- Cursor pagination (`after`) on listing tools
- Rate-limit resilience: HTTP 429 retry with `Retry-After` backoff (`REDDIT_MAX_RETRIES`)
- `get_subreddit_rules`, `get_post_flairs` + `create_post` `flair_id`/`flair_text`
- `get_more_comments` (expand truncated threads)
- Authenticated-user reads: `get_me`, `get_my_overview`, `get_my_saved`
- Typed `Either<RedditError, T>` client boundary (built on functype `Try`)
- Fix: `get_me` no longer crashes in read-only mode

### After merge
Tag `v1.5.0` on the squashed commit and push it to trigger the CI publish. Then rebuild `dist/` + reconnect the local MCP server to report 1.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
