### PR TITLE
fix(formatPostInfo): include selftext for link posts, increase truncation limits

### DIFF
--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -181,7 +181,7 @@ export function formatUserInfo(user: RedditUser): FormattedUserInfo {
 
 export function formatPostInfo(post: RedditPost): FormattedPostInfo {
   const contentType = post.isSelf ? "Text Post" : "Link Post"
-  const content = post.isSelf ? (post.selftext ?? "") : (post.url ?? "")
+  const content = post.selftext || post.url || ""
 
   const flags: readonly string[] = [
     ...(post.over18 ? ["NSFW"] : []),
@@ -192,7 +192,7 @@ export function formatPostInfo(post: RedditPost): FormattedPostInfo {
   return {
     title: post.title,
     type: contentType,
-    content: content.length > 300 ? `${content.substring(0, 297)}...` : content,
+    content: content.length > 10000 ? `${content.substring(0, 9997)}...` : content,
     author: post.author,
     subreddit: post.subreddit,
     stats: {
@@ -258,7 +258,7 @@ export function formatCommentInfo(comment: RedditComment): FormattedCommentInfo 
 
   return {
     author: comment.author,
-    content: comment.body.length > 300 ? `${comment.body.substring(0, 297)}...` : comment.body,
+    content: comment.body.length > 5000 ? `${comment.body.substring(0, 4997)}...` : comment.body,
     stats: {
       score: comment.score,
       controversiality: comment.controversiality,


### PR DESCRIPTION
## Problem

When a Reddit post is a **link post** (image, URL) with an accompanying text description, `formatPostInfo` discards the `selftext` and shows only the URL. The OP's full message is lost.

Additionally, both post content and comment bodies are truncated at 300 characters, which loses substantial content from long-form posts and comments.

## Root cause

`src/utils/formatters.ts` line 184:
```ts
const content = post.isSelf ? (post.selftext ?? "") : (post.url ?? "")
```

For link posts (`isSelf = false`), the `selftext` field is ignored entirely even though Reddit's API returns it for all post types.

## Fix

1. Show `selftext` for all post types, falling back to `url`:
   ```ts
   const content = post.selftext || post.url || ""
   ```

2. Increase post content truncation from 300 to 10000 chars
3. Increase comment body truncation from 300 to 5000 chars